### PR TITLE
Delay import of plotly until transform method to avoid possibility of circular import

### DIFF
--- a/repos/kaleido/py/kaleido/scopes/plotly.py
+++ b/repos/kaleido/py/kaleido/scopes/plotly.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from kaleido.scopes.base import BaseScope
 from _plotly_utils.utils import PlotlyJSONEncoder
-from plotly.graph_objects import Figure
 import base64
 
 
@@ -66,6 +65,7 @@ class PlotlyScope(BaseScope):
         :return: image bytes
         """
         # TODO: validate args
+        from plotly.graph_objects import Figure
         if isinstance(figure, Figure):
             figure = figure.to_dict()
 


### PR DESCRIPTION
Can't reproduce it locally, but hopefully this will close https://github.com/plotly/Kaleido/issues/22

cc @WEGFan