### PR TITLE
Add --no-sandbox and other chromium flags to Windows launch script

### DIFF
--- a/repos/win_scripts/kaleido.cmd
+++ b/repos/win_scripts/kaleido.cmd
@@ -1,4 +1,4 @@
 @echo off
 setlocal
 chdir /d "%~dp0"
-.\bin\kaleido.exe %*
+.\bin\kaleido.exe --no-sandbox --allow-file-access-from-files --disable-breakpad %*


### PR DESCRIPTION
This PR adds the chromium flags from the Linux/Mac launch scripts to the Windows launch script. These was an oversight.

Closes https://github.com/plotly/Kaleido/issues/26