### PR TITLE
Fix memory leak

### DIFF
--- a/repos/CMakeLists.txt
+++ b/repos/CMakeLists.txt
@@ -4,7 +4,7 @@ project(chromium)
 set(CMAKE_CXX_STANDARD 14)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/out/Kaleido_linux/gen)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/out/Kaleido_linux_x64/gen)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/kaleido/cc)
 
-add_executable(kaleido kaleido/cc/kaleido.cc kaleido/cc/kaleido.h kaleido/cc/scopes/Plotly.h kaleido/cc/scopes/BaseScope.h)
+add_executable(kaleido kaleido/cc/kaleido.cc kaleido/cc/kaleido.h kaleido/cc/scopes/Plotly.h kaleido/cc/scopes/Base.h)

--- a/repos/kaleido/cc/kaleido.h
+++ b/repos/kaleido/cc/kaleido.h
@@ -35,6 +35,10 @@ public:
     void OnExecutionContextCreated(const headless::runtime::ExecutionContextCreatedParams& params) override;
 
     void ExportNext();
+    void Reload();
+    void OnHeapUsageComplete(std::unique_ptr<headless::runtime::GetHeapUsageResult> result);
+    void OnHeapEvalComplete(std::unique_ptr<headless::runtime::EvaluateResult> result);
+
     void LoadNextScript();
     void OnPDFCreated(std::string responseString, std::unique_ptr<headless::page::PrintToPDFResult> result);
 
@@ -44,8 +48,10 @@ public:
 
 private:
     int contextId;
+    double jsHeapSizeLimit;
     std::string tmpFileName;
-    std::list<std::string> remainingLocalScriptsFiles;
+    std::vector<std::string> localScriptFiles;
+    size_t nextScriptIndex;
     kaleido::scopes::BaseScope *scope;
     std::unique_ptr<base::Environment> env;
     bool popplerAvailable;


### PR DESCRIPTION
closes https://github.com/plotly/Kaleido/issues/42

It appears that repeated calls to `devtools_client_->GetRuntime()->CallFunctionOn` result in a slow memory leak. I wasn't able to track down the cause, and it may be chromium itself (see https://github.com/puppeteer/puppeteer/issues/5893 for example).

This PR works around the issue by tracking the current JavaScript heap usage after each image export operation. When the usage exceeds 50% of the heap limit, then the page is reloaded, which does seem to effectively clear memory usage. There is a performance hit of a couple hundred milliseconds to perform this refresh, which is why I didn't do it for each export operation.

For reference, using the large figures from #42, this page reloading happens every ~20 export operations. For smaller figures, it will be much less frequent.

cc @36000