### PR TITLE
Various python updates (plotGlPixelRatio, template dimensions, json engine, AWS Lambda)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,9 @@ jobs:
     steps:
       - checkout
       - run: echo $Host.Version
-      - run: .\repos\win_scripts\fetch_chromium.ps1
+      - run:
+            command: .\repos\win_scripts\fetch_chromium.ps1
+            no_output_timeout: 30m
       - persist_to_workspace:
           root: ./repos
           paths:

--- a/repos/kaleido/js/src/plotly/constants.js
+++ b/repos/kaleido/js/src/plotly/constants.js
@@ -34,9 +34,6 @@ module.exports = {
 
   mathJaxConfigQuery: '?config=TeX-AMS-MML_SVG',
 
-  // config option passed in render step
-  plotGlPixelRatio: 2.5,
-
   // time [in ms] after which printToPDF errors when image isn't loaded
   pdfPageLoadImgTimeout: 20000
 }

--- a/repos/kaleido/js/src/plotly/render.js
+++ b/repos/kaleido/js/src/plotly/render.js
@@ -38,14 +38,14 @@ function render (info, mapboxAccessToken, topojsonURL) {
 
   // Use parsed export request
   info = parsed.result;
-  const figure = info.figure
-  const format = info.format
-  const encoded = info.encoded
+  const figure = info.figure;
+  const format = info.format;
+  const encoded = info.encoded;
 
   // Build default config, and let figure.config override it
   const defaultConfig = {
     mapboxAccessToken: opts.mapboxAccessToken || null,
-    plotGlPixelRatio: opts.plotGlPixelRatio || cst.plotGlPixelRatio
+    plotGlPixelRatio: info.scale * 2
   }
   if (opts.topojsonURL) {
     defaultConfig.topojsonURL = opts.topojsonURL

--- a/repos/kaleido/py/kaleido/scopes/base.py
+++ b/repos/kaleido/py/kaleido/scopes/base.py
@@ -18,11 +18,17 @@ class BaseScope(object):
     # flags to configure scope
     _scope_flags = ()
 
+    # Specify default chromium arguments
     _default_chromium_args = (
         "--disable-gpu",
         "--allow-file-access-from-files",
         "--disable-breakpad",
         "--disable-dev-shm-usage",
+    ) + (
+        # Add "--single-process" when running on AWS Lambda. Flag is described
+        # as for debugging only by the chromium project, but it's the only way to get
+        # chromium headless working on Lambda
+        ("--single-process",) if os.environ.get("LAMBDA_RUNTIME_DIR", None) else ()
     )
 
     _scope_chromium_args = ()

--- a/repos/kaleido/py/kaleido/scopes/base.py
+++ b/repos/kaleido/py/kaleido/scopes/base.py
@@ -14,9 +14,6 @@ except ImportError:
 
 
 class BaseScope(object):
-    # Subclasses may override to specify a custom JSON encoder for input data
-    _json_encoder = None
-
     # Tuple of class properties that will be passed as command-line
     # flags to configure scope
     _scope_flags = ()
@@ -274,6 +271,9 @@ Searched for executable 'kaleido' on the following system PATH:
         self._chromium_args = tuple(val)
         self._shutdown_kaleido()
 
+    def _json_dumps(self, val):
+        return json.dumps(val)
+
     def _perform_transform(self, data, **kwargs):
         """
         Transform input data using the current scope, returning dict response with error code
@@ -287,9 +287,7 @@ Searched for executable 'kaleido' on the following system PATH:
         self._ensure_kaleido()
 
         # Perform export
-        export_spec = json.dumps(
-            dict(kwargs, data=data),
-            cls=self._json_encoder).encode('utf-8')
+        export_spec = self._json_dumps(dict(kwargs, data=data)).encode('utf-8')
 
         # Write to process and read result within a lock so that can be
         # sure we're reading the response to our request

--- a/repos/kaleido/py/kaleido/scopes/plotly.py
+++ b/repos/kaleido/py/kaleido/scopes/plotly.py
@@ -115,9 +115,19 @@ class PlotlyScope(BaseScope):
         # Get figure layout
         layout = figure.get("layout", {})
 
-        # Compute default width / height
-        width = width or layout.get("width", None) or self.default_width
-        height = height or layout.get("height", None) or self.default_height
+        # Compute image width / height
+        width = (
+                width
+                or layout.get("width", None)
+                or layout.get("template", {}).get("layout", {}).get("width", None)
+                or self.default_width
+        )
+        height = (
+                height
+                or layout.get("height", None)
+                or layout.get("template", {}).get("layout", {}).get("height", None)
+                or self.default_height
+        )
 
         # Normalize format
         original_format = format

--- a/repos/kaleido/py/kaleido/scopes/plotly.py
+++ b/repos/kaleido/py/kaleido/scopes/plotly.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from kaleido.scopes.base import BaseScope, which
-from _plotly_utils.utils import PlotlyJSONEncoder
+import plotly.io as pio
 import base64
 import os
 from pathlib import Path
@@ -10,7 +10,6 @@ class PlotlyScope(BaseScope):
     """
     Scope for transforming Plotly figures to static images
     """
-    _json_encoder = PlotlyJSONEncoder
     _all_formats = ("png", "jpg", "jpeg", "webp", "svg", "pdf", "eps", "json")
     _text_formats = ("svg", "json", "eps")
 
@@ -72,6 +71,9 @@ class PlotlyScope(BaseScope):
     @property
     def scope_name(self):
         return "plotly"
+
+    def _json_dumps(self, val):
+        return pio.to_json(val, validate=False, remove_uids=False)
 
     def transform(self, figure, format=None, width=None, height=None, scale=None):
         """


### PR DESCRIPTION
This PR bundles several fixes and improvements

### Honor plotly figure's template dimensions
Closes https://github.com/plotly/Kaleido/issues/62 by honoring the width/height specifications stored in the plotly figure template.
(0fa6083)

### Set default plotGlPixelRatio based on the scale factor
Addresses the Kaleido portion of https://github.com/plotly/Kaleido/issues/58 by setting the default value of `plotGlPixelRatio` to twice the image scale factor. Note that not all of the WebGL plotly.js trace types honor this property yet (see https://github.com/plotly/plotly.js/pull/5500 for work on that front)
(42234c3)

### Refactor JSON encoding to take advantage of future plotly.py performance enhancements
Refactors how plotly.py JSON encoding is performed to take advantage of the future JSON encoding performance enhancements coming in plotly.py version 5 (see https://github.com/plotly/plotly.py/pull/2955)
(eb7dfb8)

### Default AWS Lambda support
 Add `--single-process` chromium flag to default set when we detect that we're running on AWS Lambda. See https://github.com/plotly/Kaleido/issues/74. cc @carterthayer
(fa3cd67)
