### PR TITLE
Added 32-bit Arm gn file

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ There are two approaches to building Kaleido on Linux, both of which rely on Doc
 The Linux build relies on the `jonmmease/chromium-builder` docker image, and the scripts in `repos/linux_scripts`, to download the chromium source to a local folder and then build it.
 Download docker image
 ```
-$ docker pull jonmmease/chromium-builder:0.8
+$ docker pull jonmmease/chromium-builder:0.9
 ```
 
 Fetch the Chromium codebase and checkout the specific tag, then sync all dependencies
@@ -188,14 +188,14 @@ The `chromium-builder` container mostly follows the instructions at https://chro
 Build container with:
 
 ```
-$ docker build -t jonmmease/chromium-builder:0.8 -f repos/linux_scripts/Dockerfile .
+$ docker build -t jonmmease/chromium-builder:0.9 -f repos/linux_scripts/Dockerfile .
 ```
 
 ## kaleido-builder
 This container contains a pre-compiled version of chromium source tree. Takes several hours to build!
 
 ```
-$ docker build -t jonmmease/kaleido-builder:0.8 -f repos/linux_full_scripts/Dockerfile .
+$ docker build -t jonmmease/kaleido-builder:0.9 -f repos/linux_full_scripts/Dockerfile .
 ```
 
 

--- a/repos/linux_scripts/args_arm.gn
+++ b/repos/linux_scripts/args_arm.gn
@@ -1,0 +1,9 @@
+import("//build/args/headless.gn")
+enable_nacl=false
+is_component_build=false
+
+symbol_level=0
+blink_symbol_level=0
+is_debug=false
+
+target_cpu="arm"


### PR DESCRIPTION
It seems like the docker images can compile for Arm 32-bit now. I needed this to run on a headless RaspberryPi, and it appears to work just fine after installing libnss3.

I also updated the README.md to refer to the current docker image (jonmmease/chromium-builder:0.9) that's pulled in the build_kaleido script as of Commit https://github.com/plotly/Kaleido/commit/37e6ec424e16fce67101cde5ed2f2aa9ba512610

Let me know if you would prefer these two changes to be two separate PRs. Thanks for taking the time to make it easy to build from source!