### PR TITLE
Set daemon attribute directly

### DIFF
--- a/repos/kaleido/py/kaleido/scopes/base.py
+++ b/repos/kaleido/py/kaleido/scopes/base.py
@@ -185,7 +185,7 @@ Searched for executable 'kaleido' on the following system PATH:
                     # Set up thread to asynchronously collect standard error stream
                     if self._std_error_thread is None or not self._std_error_thread.is_alive():
                         self._std_error_thread = Thread(target=self._collect_standard_error)
-                        self._std_error_thread.setDaemon(True)
+                        self._std_error_thread.daemon = True
                         self._std_error_thread.start()
 
                     # Read startup message and check for errors


### PR DESCRIPTION
setDaemon() has been deprecated in favor of setting daemon attribute directly in Python 3.10. 

See: [python/cpython#25174](https://github.com/python/cpython/pull/25174)