### PR TITLE
Attempt to fix static image export hanging by flushing after printing JSON

### DIFF
--- a/repos/kaleido/cc/utils.h
+++ b/repos/kaleido/cc/utils.h
@@ -19,7 +19,7 @@ namespace kaleido {
             std::string error = base::StringPrintf(
                     "{\"code\": %d, \"message\": \"%s\", \"result\": null, \"version\": \"%s\"}\n",
                     code, message.c_str(), version.c_str());
-            std::cout << error;
+            std::cout << error << std::flush;
         }
     }
 }


### PR DESCRIPTION
This is a potentially "wishful thinking" attempt to fix (a subset of?) the "writing image stalls" problem with a dozen or so open issues. Unfortunately I haven't been able to test whether it fixes the issue, because I do not have the tooling at hand to build the library (assuming this indeed involves the 50 GB chromium compile). If there's a low-profile way to compile this patch I'd love to test it locally on my "known bad" setup.

#### My situation:
1. A coworker and I have almost identical hardware, identical OS version (down to the exact Windows build) and the exact same conda environment. His conda is 4.8 and mine is 4.11, but other than this I couldn't pin down any differences between our setups. For the time being we're stuck with plotly 4.11.0.
2. Any call to `fig.write_image()` will hang on my machine, and it will always succeed on coworker's machine. (So it's not the "sometimes hangs on the same system" case some people see.)
3. I get a hang in any shell I can find: git-bash, cmd, powershell, even WSL. (So it's not the "doesn't work in WSL only" case some people see.)
4. The hang always happens in the usual suspect `self._proc.stdout.readline()` line in `_ensure_kaleido()`, see e.g. traceback in https://github.com/plotly/Kaleido/issues/36#issuecomment-756614157
5. Running the subprocess' corresponding command directly in the shell gives the same output as https://github.com/plotly/Kaleido/issues/110#issuecomment-924929419, where the stdout JSON payload even has a trailing newline as it should.
6. Disabling mathjax doesn't help. Nor does disabling internet entirely. And the hang never ended during the 3-hour slot I let it run once. (So it's probably not the "kaleido waits for timeout" case some people see.)

#### Buffering?
The only thing I can suspect here is buffering. If for some reason the process is not line buffered (and kaleido runs the subprocess with a binary stdout stream, so I'm not even sure line buffering is a thing there), the `readline()` call might be stuck, waiting for the stdout stream to flush, which for some reason might not happen on some systems.

Why it might not be buffering:
1. It's quite surprising if two essentially identical systems (those of coworker and I) have markedly different buffering behaviour.
2. The newline seems to be printed fine, which normally should flush assuming line buffering (but, again, this is a binary stream for now).
3. Editing the library to open the subprocess with text mode streams via `universal_newlines=True` doesn't make the problem go away. Manually calling `self._proc.stdout.flush()` doesn't make the problem go away. Accessing `self._proc.stdout.raw` which might be less buffered doesn't make the problem go away. Calling `self._proc.stdout.read(70)` or even `.read(50)` (since we expect 70 characters for the JSON) halts all the same.
4. Trying to reproduce the issue running a small python script that prints a similar linefeed-terminated line (run through the same `subprocess.Popen` setup) doesn't stall.
5. Editing the library to open the subprocess with `bufsize=50` (say) which is shorter than the 70 bytes of the expected JSON doesn't make the problem go away (it still stalls).

Why it might be buffering:
1. This would explain why the `readline()` call freezes in the subprocess call (JSON is stuck in the buffer).
2. The JSON writer adds the linefeed to the string rather than calling `std::endl` which would flush.
3. Frankly, I have no other idea and the manual flush in this patch seems harmless enough to try, considering that the mysterious issue has been around for a long time.

Unfortunately I couldn't find any exact information on what kind of buffering options are available on a given OS, and what defaults are. The only thing I could figure out is that both in my native Windows and in my WSL the `io.DEFAULT_BUFFER_SIZE` is 8192, so if the output is _not_ line buffered then it would take a lot of output to get it flushed (assuming I even understand the mechanics here correctly).