### PR TITLE
[Python] Display error stream when interrupting the program

### DIFF
--- a/repos/kaleido/py/kaleido/scopes/base.py
+++ b/repos/kaleido/py/kaleido/scopes/base.py
@@ -305,7 +305,11 @@ Searched for executable 'kaleido' on the following system PATH:
             self._proc.stdin.write(export_spec)
             self._proc.stdin.write("\n".encode('utf-8'))
             self._proc.stdin.flush()
-            response = self._proc.stdout.readline()
+            try:
+                response = self._proc.stdout.readline()
+            except BaseException:  # allows to catch KeyboardInterrupt = CTRL+C
+                print("Error stream:\n", self._get_decoded_std_error())
+                raise
 
         response_string = response.decode('utf-8')
         if not response_string:


### PR DESCRIPTION
Hi,

I am currently facing a case of Kaleido hanging forever, from Python code calling `plotly.graph_objects.Figure.to_image(format="png", engine="kaleido")`.
I hope that this PR may be the solution I need: https://github.com/plotly/Kaleido/pull/149

In the meantime, adding those 3 lines allowed me access to the `executable/bin/kaleido` stderr when interrupting the whole program using CTRL+C:
```
Error stream:
[0308/083633.564952:ERROR:platform_shared_memory_region_posix.cc(47)] Descriptor access mode (0) differs from expected (2)
[0308/083633.565438:FATAL:platform_shared_memory_region_posix.cc(100)] Check failed: CheckPlatformHandlePermissionsCorrespondToMode(handle.get(), mode, size).
...
```
For this reason, it seems to me a useful an innocuous patch.