### PR TITLE
switch from #!/bin/bash to #!/usr/bin/env bash

### DIFF
--- a/repos/linux_scripts/build_kaleido
+++ b/repos/linux_scripts/build_kaleido
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ $# -eq 0 ]; then
     echo "No architecture provided"
     exit 1

--- a/repos/linux_scripts/build_kaleido_docker
+++ b/repos/linux_scripts/build_kaleido_docker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # docker run -it -v /media/jmmease/SSD1/chromium_build/repos/:/repos  jonmmease/chromium-builder:0.9 /repos/build_headless
 if [ $# -eq 0 ]; then
     echo "No architecture provided"

--- a/repos/linux_scripts/bundle_artifacts
+++ b/repos/linux_scripts/bundle_artifacts
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ $# -eq 0 ]; then
     echo "No architecture provided"
     exit 1

--- a/repos/linux_scripts/bundle_artifacts_docker
+++ b/repos/linux_scripts/bundle_artifacts_docker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ $# -eq 0 ]; then
     echo "No architecture provided"
     exit 1

--- a/repos/linux_scripts/checkout_revision_docker
+++ b/repos/linux_scripts/checkout_revision_docker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 CHROMIUM_TAG="88.0.4324.150"
 
 # Replace any prior .gclient file

--- a/repos/linux_scripts/fetch_chromium_docker
+++ b/repos/linux_scripts/fetch_chromium_docker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # docker run -it -v /media/jmmease/SSD1/chromium_build/repos/:/repos  jonmmease/chromium-builder:0.9 /repos/fetch_chromium_docker
 
 # Update depot tools for fetch

--- a/repos/linux_scripts/launch_script
+++ b/repos/linux_scripts/launch_script
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 export LD_LIBRARY_PATH=$DIR/lib:$LD_LIBRARY_PATH

--- a/repos/linux_scripts/minimal_launch_script
+++ b/repos/linux_scripts/minimal_launch_script
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 unset LD_PRELOAD
 

--- a/repos/mac_scripts/build_blink
+++ b/repos/mac_scripts/build_blink
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $# -eq 0 ]; then
     echo "No architecture provided"

--- a/repos/mac_scripts/build_kaleido
+++ b/repos/mac_scripts/build_kaleido
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $# -eq 0 ]; then
     echo "No architecture provided"
@@ -84,7 +84,7 @@ cp ./out/Kaleido_mac_$KALEIDO_ARCH/libGLES*.dylib ../build/kaleido/bin
 cp ./out/Kaleido_mac_$KALEIDO_ARCH/libEGL*.dylib ../build/kaleido/bin
 
 # launch script
-echo "#!/bin/bash
+echo "#!/usr/bin/env bash
 DIR=\"\$( cd \"\$( dirname \"\${BASH_SOURCE[0]}\" )\" >/dev/null 2>&1 && pwd )\"
 
 cd \$DIR

--- a/repos/mac_scripts/fetch_chromium
+++ b/repos/mac_scripts/fetch_chromium
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Commits
 DEPOT_TOOLS_COMMIT=e342fb1


### PR DESCRIPTION
This allows for more portability to BSDs, and other
linux package managers that may not install to /bin.
