### PR TITLE
Changed chdir /d to pushd to better handle network pathing

### DIFF
--- a/repos/win_scripts/kaleido.cmd
+++ b/repos/win_scripts/kaleido.cmd
@@ -1,4 +1,4 @@
 @echo off
 setlocal
-chdir /d "%~dp0"
+pushd "%~dp0"
 .\bin\kaleido.exe %*


### PR DESCRIPTION
Changed chdir to pushd in kaleido.cmd. This fixes issues with using environments that call packages from Windows network locations. Pushd is still compatible with all other directories/locations.