### PR TITLE
Properly quote unix launch scripts

### DIFF
--- a/repos/linux_scripts/build_kaleido
+++ b/repos/linux_scripts/build_kaleido
@@ -9,7 +9,7 @@ export KALEIDO_ARCH=$1
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # cd to the top-level project directory
-cd $DIR/../..
+cd "$DIR/../.."
 
 # Update version based on git tags
 python ./repos/version/build_pep440_version.py

--- a/repos/linux_scripts/fetch_chromium
+++ b/repos/linux_scripts/fetch_chromium
@@ -2,11 +2,11 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # cd to the top-level project directory
-cd $DIR/../..
+cd "$DIR/../.."
 echo `pwd`
 
 # Download chromium
-docker run -it -v `pwd`/repos/:/repos  jonmmease/chromium-builder:0.9 /repos/linux_scripts/fetch_chromium_docker
+docker run -it -v "`pwd`/repos/:/repos"  jonmmease/chromium-builder:0.9 /repos/linux_scripts/fetch_chromium_docker
 
 # Checkout revision
-docker run -it -v `pwd`/repos/:/repos  jonmmease/chromium-builder:0.9 /repos/linux_scripts/checkout_revision_docker
+docker run -it -v "`pwd`/repos/:/repos"  jonmmease/chromium-builder:0.9 /repos/linux_scripts/checkout_revision_docker

--- a/repos/linux_scripts/launch_script
+++ b/repos/linux_scripts/launch_script
@@ -1,10 +1,10 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-export LD_LIBRARY_PATH=$DIR/lib:$LD_LIBRARY_PATH
-export FONTCONFIG_PATH=$DIR/etc/fonts
-export XDG_DATA_HOME=$DIR/xdg
+export LD_LIBRARY_PATH="$DIR/lib:$LD_LIBRARY_PATH"
+export FONTCONFIG_PATH="$DIR/etc/fonts"
+export XDG_DATA_HOME="$DIR/xdg"
 unset LD_PRELOAD
 
-cd $DIR
-./bin/kaleido $@
+cd "$DIR"
+./bin/kaleido "$@"

--- a/repos/linux_scripts/minimal_launch_script
+++ b/repos/linux_scripts/minimal_launch_script
@@ -2,5 +2,5 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 unset LD_PRELOAD
 
-cd $DIR
-./bin/kaleido --no-sandbox --allow-file-access-from-files --disable-breakpad $@
+cd "$DIR"
+./bin/kaleido --no-sandbox --allow-file-access-from-files --disable-breakpad "$@"

--- a/repos/mac_scripts/build_blink
+++ b/repos/mac_scripts/build_blink
@@ -1,32 +1,42 @@
 #!/bin/bash
 
+
 if [ $# -eq 0 ]; then
     echo "No architecture provided"
     exit 1
 fi
 
+
 export KALEIDO_ARCH=$1
+
 
 # Don't autoupdate depottools version
 export DEPOT_TOOLS_UPDATE=0
 
+
 # full path to mac_scripts/ directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+
 # cd to repos directory
-cd $DIR/..
+cd "$DIR/.."
+
 
 # Add depot_tools directory to PATH
 export PATH="$PATH:`pwd`/depot_tools"
 
+
 # Make output directory
 mkdir -p ./src/out/Kaleido_mac_$KALEIDO_ARCH/
+
 
 # Write out/Kaleido_mac_$KALEIDO_ARCH/args.gn
 cp ./mac_scripts/args_$KALEIDO_ARCH.gn ./src/out/Kaleido_mac_$KALEIDO_ARCH/args.gn
 
+
 # cd to repos/src
 cd src
+
 
 # 4) Perform build, result will be out/Kaleido_mac_$KALEIDO_ARCH/kaleido
 gn gen out/Kaleido_mac_$KALEIDO_ARCH

--- a/repos/mac_scripts/build_kaleido
+++ b/repos/mac_scripts/build_kaleido
@@ -78,3 +78,55 @@ ninja -C out/Kaleido_mac_$KALEIDO_ARCH -j 8 kaleido
 if [ ! -f "out/Kaleido_mac_$KALEIDO_ARCH/kaleido" ]
 then
   echo "Error: Kaleido executable was not built";
+  exit 1
+fi
+
+# 5) Copy build files
+mkdir -p ../build/kaleido/
+rm -r ../build/kaleido/*
+mkdir -p ../build/kaleido/bin
+cp out/Kaleido_mac_$KALEIDO_ARCH/kaleido ../build/kaleido/bin
+
+# mathjax
+mkdir -p ../build/kaleido/etc
+unzip ../vendor/Mathjax-2.7.5.zip -d ../build/kaleido/etc/
+mv ../build/kaleido/etc/Mathjax-2.7.5 ../build/kaleido/etc/mathjax
+
+# Copy icudtl.dat and settings.dat
+cp ./out/Kaleido_mac_$KALEIDO_ARCH/icudtl.dat ../build/kaleido/bin
+
+# Copy dynamic libraries
+cp ./out/Kaleido_mac_$KALEIDO_ARCH/libswiftshader*.dylib ../build/kaleido/bin
+cp ./out/Kaleido_mac_$KALEIDO_ARCH/libGLES*.dylib ../build/kaleido/bin
+cp ./out/Kaleido_mac_$KALEIDO_ARCH/libEGL*.dylib ../build/kaleido/bin
+
+# launch script
+echo "#!/bin/bash
+DIR=\"\$( cd \"\$( dirname \"\${BASH_SOURCE[0]}\" )\" >/dev/null 2>&1 && pwd )\"
+cd \$DIR
+./bin/kaleido \$@
+" > ../build/kaleido/kaleido
+chmod +x ../build/kaleido/kaleido
+
+# version
+cp ../kaleido/version ../build/kaleido/
+
+# license
+cp ../kaleido/LICENSE.txt ../build/kaleido/
+cp ../kaleido/CREDITS.html ../build/kaleido/
+cp ../kaleido/README.md ../build/kaleido/
+
+# Copy javascript
+pushd ../kaleido/js/
+mkdir -p build/
+npm install
+npm run clean
+npm run build
+popd
+
+mkdir -p ../build/kaleido/js/
+cp ../kaleido/js/build/*.js ../build/kaleido/js/
+
+# Build python wheel
+cd ../kaleido/py
+python3 setup.py package

--- a/repos/mac_scripts/build_kaleido
+++ b/repos/mac_scripts/build_kaleido
@@ -1,48 +1,62 @@
 #!/bin/bash
 
+
 if [ $# -eq 0 ]; then
     echo "No architecture provided"
     exit 1
 fi
 
+
 export KALEIDO_ARCH=$1
+
 
 # Don't autoupdate depottools version
 export DEPOT_TOOLS_UPDATE=0
 
+
 # full path to mac_scripts/ directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+
 # cd to repos directory
-cd $DIR/..
+cd "$DIR/.."
+
 
 # Update version based on git tag
 python3 ./version/build_pep440_version.py
+
 
 # Copy README and LICENSE to kaleido (For consistency with Linux docker build process)
 cp ../README.md ./kaleido/
 cp ../LICENSE.txt ./kaleido/
 cp ./CREDITS.html ./kaleido/
 
+
 # Add depot_tools directory to PATH
 export PATH="$PATH:`pwd`/depot_tools"
+
 
 # Make output directory
 mkdir -p ./src/out/Kaleido_mac_$KALEIDO_ARCH/
 
+
 # Write out/Kaleido_mac_$KALEIDO_ARCH/args.gn
 cp ./mac_scripts/args_$KALEIDO_ARCH.gn ./src/out/Kaleido_mac_$KALEIDO_ARCH/args.gn
+
 
 # cd to repos/src
 cd src
 
+
 # 1) Reset headless/BUILD.gn
 git checkout HEAD -- headless/BUILD.gn
+
 
 # 2) Append kaleido section to headless build file (src/headless/BUILD.gn)
 echo "
 executable(\"kaleido\") {
   sources = [ \"app/kaleido.cc\" ]
+
 
   deps = [
     \":headless_shell_lib\",
@@ -50,67 +64,17 @@ executable(\"kaleido\") {
   ]
 }" >> headless/BUILD.gn
 
+
 # 3) Copy kaleido/kaleido.cc to src/headless/app/kaleido.cc
 rm -rf headless/app/plugins
 cp -r ../kaleido/cc/* headless/app/
+
 
 # 4) Perform build, result will be out/Kaleido_mac_$KALEIDO_ARCH/kaleido
 gn gen out/Kaleido_mac_$KALEIDO_ARCH
 ninja -C out/Kaleido_mac_$KALEIDO_ARCH -j 8 kaleido
 
+
 if [ ! -f "out/Kaleido_mac_$KALEIDO_ARCH/kaleido" ]
 then
   echo "Error: Kaleido executable was not built";
-  exit 1
-fi
-
-# 5) Copy build files
-mkdir -p ../build/kaleido/
-rm -r ../build/kaleido/*
-mkdir -p ../build/kaleido/bin
-cp out/Kaleido_mac_$KALEIDO_ARCH/kaleido ../build/kaleido/bin
-
-# mathjax
-mkdir -p ../build/kaleido/etc
-unzip ../vendor/Mathjax-2.7.5.zip -d ../build/kaleido/etc/
-mv ../build/kaleido/etc/Mathjax-2.7.5 ../build/kaleido/etc/mathjax
-
-# Copy icudtl.dat and settings.dat
-cp ./out/Kaleido_mac_$KALEIDO_ARCH/icudtl.dat ../build/kaleido/bin
-
-# Copy dynamic libraries
-cp ./out/Kaleido_mac_$KALEIDO_ARCH/libswiftshader*.dylib ../build/kaleido/bin
-cp ./out/Kaleido_mac_$KALEIDO_ARCH/libGLES*.dylib ../build/kaleido/bin
-cp ./out/Kaleido_mac_$KALEIDO_ARCH/libEGL*.dylib ../build/kaleido/bin
-
-# launch script
-echo "#!/bin/bash
-DIR=\"\$( cd \"\$( dirname \"\${BASH_SOURCE[0]}\" )\" >/dev/null 2>&1 && pwd )\"
-
-cd \$DIR
-./bin/kaleido \$@
-" > ../build/kaleido/kaleido
-chmod +x ../build/kaleido/kaleido
-
-# version
-cp ../kaleido/version ../build/kaleido/
-
-# license
-cp ../kaleido/LICENSE.txt ../build/kaleido/
-cp ../kaleido/CREDITS.html ../build/kaleido/
-cp ../kaleido/README.md ../build/kaleido/
-
-# Copy javascript
-pushd ../kaleido/js/
-mkdir -p build/
-npm install
-npm run clean
-npm run build
-popd
-
-mkdir -p ../build/kaleido/js/
-cp ../kaleido/js/build/*.js ../build/kaleido/js/
-
-# Build python wheel
-cd ../kaleido/py
-python3 setup.py package

--- a/repos/mac_scripts/fetch_chromium
+++ b/repos/mac_scripts/fetch_chromium
@@ -1,31 +1,40 @@
 #!/bin/bash
 
+
 # Commits
 DEPOT_TOOLS_COMMIT="" # Can't set a version for Windows, maybe we can for make depending on TODO below, probably won't
 CHROMIUM_TAG="124.0.6367.60"
 export DEPOT_TOOLS_UPDATE=0 # TODO: Don't know if this will work on Mac
 
+
 # full path to mac_scripts/ directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+
 # cd to repos directory
-cd $DIR/..
+cd "$DIR/.."
+
 
 # Get depot_tools
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 cd depot_tools
 
+
 # Add cloned depot_tools directory to PATH
 export PATH="$PATH:`pwd`"
+
 
 # Reset to proper commit
 git reset --hard $DEPOT_TOOLS_COMMIT
 git clean -ffd
 
+
 # Move back to repos directory
 cd ../src
 
+
 gclient sync -D --force --reset --no-history --jobs=3 --revision=$CHROMIUM_TAG 
+
 
 # Write out credits file
 cd ..


### PR DESCRIPTION
This is a classic bash bug. Without quotes, any spaces in the directory that kaleido is installed into will cause the commands to split into multiple arguments. This change fixes #78, a long-standing (3 years) and annoying issue for people using per-project venvs with spaces in the project name.