### PR TITLE
fix: use /usr/bin/env to find bash

### DIFF
--- a/toolchain/src/00-set_version.sh
+++ b/toolchain/src/00-set_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/01-fetch_tools.sh
+++ b/toolchain/src/01-fetch_tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/02-init_tools.sh
+++ b/toolchain/src/02-init_tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 
@@ -97,6 +97,7 @@ elif [[ "$PLATFORM" == "LINUX" ]]; then
 elif [[ "$PLATFORM" == "OSX" ]]; then
   $NO_VERBOSE || echo "MAC INIT IS EXPERIMENTAL"
   pushd "$MAIN_DIR/vendor/depot_tools"
+  set +u
   source "./cipd_bin_setup.sh"
   cipd_bin_setup
 
@@ -104,4 +105,7 @@ elif [[ "$PLATFORM" == "OSX" ]]; then
   # bootstrap/win_tools.bat.
   source "./bootstrap_python3"
   bootstrap_python3
+
+  set -u
+  popd
 fi

--- a/toolchain/src/03-ksync.sh
+++ b/toolchain/src/03-ksync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/04-patch_chromium.sh
+++ b/toolchain/src/04-patch_chromium.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/05-gen_preamble.sh
+++ b/toolchain/src/05-gen_preamble.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/06-build_ninja.sh
+++ b/toolchain/src/06-build_ninja.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 
@@ -101,7 +101,7 @@ $NO_VERBOSE || echo "LINE MARKER: $(head -n 1 "$BUILD_SUFFIX")"
 $NO_VERBOSE || echo "LINE NUMBER: $LINE_NO"
 if [[ -n "$LINE_NO" ]]; then
   $NO_VERBOSE || echo "Recreating original based on file"
-  head "$TARGET" -n $(($LINE_NO - 1)) > "${TARGET}.TEMP"
+  head -n $(($LINE_NO - 1)) "$TARGET" > "${TARGET}.TEMP"
   mv "${TARGET}.TEMP" "$TARGET"
 fi
 $NO_VERBOSE || echo "Appending build information to headless/BUILD.gn"

--- a/toolchain/src/07-write_kversion.sh
+++ b/toolchain/src/07-write_kversion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/08-sync_cpp.sh
+++ b/toolchain/src/08-sync_cpp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/09-build_kaleido.sh
+++ b/toolchain/src/09-build_kaleido.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/10-extract.sh
+++ b/toolchain/src/10-extract.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/11-extract_etc.sh
+++ b/toolchain/src/11-extract_etc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/12-build_js.sh
+++ b/toolchain/src/12-build_js.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/13-roll_wheel.sh
+++ b/toolchain/src/13-roll_wheel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/xx-all.sh
+++ b/toolchain/src/xx-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/xx-kdocker.sh
+++ b/toolchain/src/xx-kdocker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This is a script to help get us into a workable dev-environment inside a docker container
 # ⚠️⚠️⚠️ HERE BE DRAGONS ⚠️⚠️⚠️
 #    \****__              ____

--- a/toolchain/src/xx-krefresh.sh
+++ b/toolchain/src/xx-krefresh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/xx-make_bin.sh
+++ b/toolchain/src/xx-make_bin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/toolchain/src/xx-template.sh
+++ b/toolchain/src/xx-template.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 


### PR DESCRIPTION
Default bash on MacOS is 3.*, but these scripts need 5.*, so this PR changes the `#!` line in these shell scripts to use `/usr/bin/env bash` to find and run bash instead of using `/bin/bash`, which allows users to install a more recent version of bash and have it picked up.



from @gvwilson , here we're not merging into master