### PR TITLE
Update minimum python version

### DIFF
--- a/repos/kaleido/py/setup.py
+++ b/repos/kaleido/py/setup.py
@@ -295,7 +295,7 @@ setup(
     long_description_content_type="text/markdown",
     license="MIT",
     install_requires=[
-        "pathlib ; python_version<'3.4'",
+        "pathlib ; python_version>'3.4'",
     ],
     packages=["kaleido", "kaleido.scopes"],
     package_data={


### PR DESCRIPTION
Poetry will not install Kaleida as the maximum Python version is 3.4. 