### PR TITLE
Update README.md

### DIFF
--- a/.github/workflows/publish_testpypi.yml
+++ b/.github/workflows/publish_testpypi.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python_v: ['3.8', '3.9', '3.10', '']
-        chrome_v: ['-1']
+        # chrome_v: ['-1']
     defaults:
       run:
         working-directory: ./src/py/
@@ -38,7 +38,7 @@ jobs:
           uv pip install dist/kaleido-$(uv
           run --no-sync --with setuptools-git-versioning
           setuptools-git-versioning)-py3-none-any.whl
-      - run: uv run --no-sync kaleido_get_chrome -v --i ${{ matrix.chrome_v }}
+      - run: uv run --no-sync kaleido_get_chrome -v # --i ${{ matrix.chrome_v }}
       - name: Diagnose
         run:  uv run --no-sync choreo_diagnose --no-run
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           --all-extras
 
       - name: Install google-chrome-for-testing
-        run: uv run --no-sources kaleido_get_chrome
+        run: uv run --no-sources kaleido_get_chrome -v
 
       - name: Test mocker
         run: >

--- a/README.md
+++ b/README.md
@@ -1,3 +1,59 @@
+# Launch Kaleido v1.0.0
+
+Right now, Kaledio v1.0.0 is available as a release candidate:
+
+* download `v1.0.0rc1` explicitly
+* enable whatever installer you use (`pip --pre`?) to use release candidates
+
+Kaleido's strategy has changed: `chrome` is no longer included. On the other hand,
+it's *much* faster and supports parallel processing and memory-saving techniques.
+
+Kaleido will try to use your own platform's `chrome`, but we recommend the following:
+
+```
+$ kaleido_get_chrome
+```
+
+or
+
+```python
+
+import kaleido
+await kaleido.get_chrome()
+# or
+# kaleido.get_chrome_sync()
+```
+
+## Quickstart
+
+```python
+import kaleido
+
+# fig is a plotly figure or an iterable of plotly figures
+
+async with kaleido.Kaleido(n=4, timeout=60) as k: # Those are the defaults! 4 processes, 60 seconds.
+	await k.write_fig(fig, path="./", opts={"format":"jpg"}) # default format is `png`
+```
+
+If you have to print thousands of graphs, fig can be a generator to save memory.
+It can also just be a single graph.
+
+There is a shortcut function:
+
+```
+import asyncio
+import kaleido
+asyncio.run(kaleido.write_fig(fig, path="./", n=4))
+# this will spin the kaleido process for you with 4 processors
+```
+
+If you're not using async/await, wrap it all in an async function and:
+```
+asyncio.run(my_async_wrapper())
+```
+
+#### Older Readme Below ####
+
 # Kaleido
 
 Kaleido is a cross-platform library for generating static images for [Plotly][plotly]'s

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
-# Launch Kaleido v1.0.0
+
+<div align="center">
+  <a href="https://dash.plotly.com/project-maintenance">
+    <img src="https://dash.plotly.com/assets/images/maintained-by-plotly.png"
+    width="400px" alt="Maintained by Plotly">
+  </a>
+</div>
+
+# Pre-Launch Kaleido v1.0.0
+
+Kaleido allows you to convert plotly figures to images.
+
+`pip install kaleido`
 
 Right now, Kaledio v1.0.0 is available as a release candidate:
 
-* download `v1.0.0rc1` explicitly
+* download `v1.0.0rc2` explicitly **or**
 * enable whatever installer you use (`pip --pre`?) to use release candidates
 
 Kaleido's strategy has changed: `chrome` is no longer included. On the other hand,
@@ -31,82 +43,62 @@ import kaleido
 
 # fig is a plotly figure or an iterable of plotly figures
 
-async with kaleido.Kaleido(n=4, timeout=60) as k: # Those are the defaults! 4 processes, 60 seconds.
-	await k.write_fig(fig, path="./", opts={"format":"jpg"}) # default format is `png`
+# Those are the defaults! 4 processes, 90 seconds.
+async with kaleido.Kaleido(n=4, timeout=90) as k:
+  await k.write_fig(fig, path="./", opts={"format":"jpg"}) # default format is `png`
+
+# Kaleido arguments:
+# - n: how many processors to use
+# - timeout: Set a timeout on any single image write
+# - page: Customize the version of mathjax/plotly used
+
+# Kaleido.write_fig arguments:
+# - fig: a single plotly figure or an iterable
+# - path: A directory (names will be auto-generated based on title) or a single file
+# - opts: a dictionary with image options:
+#         {"scale":, "format":, "width":, "height":}
+# - error_log: If you pass a list here, image-generation errors will be appended
+#              to the list and generation continues. If left as None, the first error
+#              will cause failure.
+
+# You can also use Kaleido.write_fig_from_object:
+  await k.write_fig_from_object(fig_objects, error_log)
+
+# where fig_objects is an iterable of dictionaries that have
+# {"fig":, "path":, "opts":} keys corresponding to above.
 ```
 
-If you have to print thousands of graphs, fig can be a generator to save memory.
-It can also just be a single graph.
-
-There is a shortcut function:
+There are shortcut functions if just want dont want to create a `Kaleido()`.
 
 ```
 import asyncio
 import kaleido
-asyncio.run(kaleido.write_fig(fig, path="./", n=4))
-# this will spin the kaleido process for you with 4 processors
+asyncio.run(
+            kaleido.write_fig(
+                              fig,
+                              path="./",
+                              n=4
+                              )
+            )
 ```
 
-If you're not using async/await, wrap it all in an async function and:
-```
-asyncio.run(my_async_wrapper())
-```
+However, if you want to set timeout or custom page, you must use a `Kaleido()`.
 
-#### Older Readme Below ####
+## PageGenerators
 
-# Kaleido
-
-Kaleido is a cross-platform library for generating static images for [Plotly][plotly]'s
-visualization library. After installing it, you can use `fig.write_image("filename.png")`
-to save a plot to a file.
-
-<div align="center">
-  <a href="https://dash.plotly.com/project-maintenance">
-    <img src="https://dash.plotly.com/assets/images/maintained-by-plotly.png"
-    width="400px" alt="Maintained by Plotly">
-  </a>
-</div>
-
-## How It Works
-
-The original version of kaleido included a custom build of the Chrome web browser,
-which made it very large (hundreds of megabytes) and proved very difficult to maintain.
-In contrast, this version depends on [choreographer][choreographer],
-a lightweight library that enables remote control of browsers from Python.
-When you ask kaleido to create an image, it uses choreographer to run a headless
-instance of Chrome to render and save your figure. Please see choreographer's
-ocumentation for details.
-
-> The new version of kaleido is a work on progress;
-> we would be grateful for help testing it and improving it.
-> If you find a bug, please report it in [our GitHub repository][repo],
-> and please include a minimal reproducible example if you can.
->
-> It would also be very helpful to run the script `src/py/tests/manual.py`
-> and attach its zipped output to your bug report.
-> This will give us detailed information about the precise versions of software you
-> are using and the platform you are running on,
-> which will help us track down problems more quickly.
-
-## Installation
-
-You can install kaleido from [PyPI][pypi] using pip:
+`Kaleido(page=???)` takes a `kaleido.PageGenerator()` to customize versions.
 
 ```
-pip install kaleido
+my_page = kaleido.PageGenerator(
+                      plotly="A fully qualified link to plotly (https:// or file://)",
+                      mathjax=False # no mathjax, or another fully quality link
+                      others=["a list of other script links to include"]
+                      )
+async with kaleido.Kaleido(n=4, page=my_page) as k:
+  ...
 ```
 
-## Use
-
-Versions 4.9 and above of the Plotly Python library will automatically use kaleido
-for static image export when kaleido is installed.
-For example:
-
-```python
-import plotly.express as px
-fig = px.scatter(px.data.iris(), x="sepal_length", y="sepal_width", color="species")
-fig.write_image("figure.png", engine="kaleido")
-```
+## More info
 
 See the [Plotly static image export documentation][plotly-export] for more information.
 

--- a/src/py/README.md
+++ b/src/py/README.md
@@ -1,3 +1,59 @@
+# Launch Kaleido v1.0.0
+
+Right now, Kaledio v1.0.0 is available as a release candidate:
+
+* download `v1.0.0rc1` explicitly
+* enable whatever installer you use (`pip --pre`?) to use release candidates
+
+Kaleido's strategy has changed: `chrome` is no longer included. On the other hand,
+it's *much* faster and supports parallel processing and memory-saving techniques.
+
+Kaleido will try to use your own platform's `chrome`, but we recommend the following:
+
+```
+$ kaleido_get_chrome
+```
+
+or
+
+```python
+
+import kaleido
+await kaleido.get_chrome()
+# or
+# kaleido.get_chrome_sync()
+```
+
+## Quickstart
+
+```python
+import kaleido
+
+# fig is a plotly figure or an iterable of plotly figures
+
+async with kaleido.Kaleido(n=4, timeout=60) as k: # Those are the defaults! 4 processes, 60 seconds.
+	await k.write_fig(fig, path="./", opts={"format":"jpg"}) # default format is `png`
+```
+
+If you have to print thousands of graphs, fig can be a generator to save memory.
+It can also just be a single graph.
+
+There is a shortcut function:
+
+```
+import asyncio
+import kaleido
+asyncio.run(kaleido.write_fig(fig, path="./", n=4))
+# this will spin the kaleido process for you with 4 processors
+```
+
+If you're not using async/await, wrap it all in an async function and:
+```
+asyncio.run(my_async_wrapper())
+```
+
+#### Older Readme Below ####
+
 # Kaleido
 
 Kaleido is a cross-platform library for generating static images for [Plotly][plotly]'s

--- a/src/py/README.md
+++ b/src/py/README.md
@@ -1,3 +1,4 @@
+# Pre-Launch Kaleido v1.0.0
 
 <div align="center">
   <a href="https://dash.plotly.com/project-maintenance">
@@ -6,11 +7,11 @@
   </a>
 </div>
 
-# Pre-Launch Kaleido v1.0.0
-
 Kaleido allows you to convert plotly figures to images.
 
-`pip install kaleido`
+```
+$ pip install kaleido # use --pre for release candidates
+```
 
 Right now, Kaledio v1.0.0 is available as a release candidate:
 
@@ -41,31 +42,30 @@ await kaleido.get_chrome()
 ```python
 import kaleido
 
-# fig is a plotly figure or an iterable of plotly figures
+# fig is a plotly figure(s)
 
-# Those are the defaults! 4 processes, 90 seconds.
+# 4 processes, 90 seconds, "png" are defaults
 async with kaleido.Kaleido(n=4, timeout=90) as k:
-  await k.write_fig(fig, path="./", opts={"format":"jpg"}) # default format is `png`
+  await k.write_fig(fig, path="./", opts={"format":"jpg"})
 
 # Kaleido arguments:
-# - n: how many processors to use
-# - timeout: Set a timeout on any single image write
-# - page: Customize the version of mathjax/plotly used
+# - n:       Set number of processors to use.
+# - timeout: Set a timeout on any single image write.
+# - page:    Customize the version of mathjax/plotly used.
 
-# Kaleido.write_fig arguments:
-# - fig: a single plotly figure or an iterable
-# - path: A directory (names will be auto-generated based on title) or a single file
-# - opts: a dictionary with image options:
-#         {"scale":, "format":, "width":, "height":}
+# `Kaleido.write_fig` arguments:
+# - fig:       A single plotly figure or an iterable.
+# - path:      A directory (names based on fig title) or a single file.
+# - opts:      A dictionary with image options:
+#              {"scale":..., "format":..., "width":..., "height":...}
 # - error_log: If you pass a list here, image-generation errors will be appended
 #              to the list and generation continues. If left as None, the first error
 #              will cause failure.
 
-# You can also use Kaleido.write_fig_from_object:
+# Or use `Kaleido.write_fig_from_object`:
   await k.write_fig_from_object(fig_objects, error_log)
-
-# where fig_objects is an iterable of dictionaries that have
-# {"fig":, "path":, "opts":} keys corresponding to above.
+# where `fig_objects` is an iterable of dictionaries that have
+# {"fig":, "path":, "opts":} keys corresponding `write_fig`'s arguments.
 ```
 
 There are shortcut functions if just want dont want to create a `Kaleido()`.
@@ -74,15 +74,15 @@ There are shortcut functions if just want dont want to create a `Kaleido()`.
 import asyncio
 import kaleido
 asyncio.run(
-            kaleido.write_fig(
-                              fig,
-                              path="./",
-                              n=4
-                              )
-            )
+          kaleido.write_fig(
+                    fig,
+                    path="./",
+                    n=4
+          )
+)
 ```
 
-However, if you want to set timeout or custom page, you must use a `Kaleido()`.
+If you want to set timeout or custom page, use a `Kaleido()`.
 
 ## PageGenerators
 

--- a/src/py/README.md
+++ b/src/py/README.md
@@ -1,8 +1,20 @@
-# Launch Kaleido v1.0.0
+
+<div align="center">
+  <a href="https://dash.plotly.com/project-maintenance">
+    <img src="https://dash.plotly.com/assets/images/maintained-by-plotly.png"
+    width="400px" alt="Maintained by Plotly">
+  </a>
+</div>
+
+# Pre-Launch Kaleido v1.0.0
+
+Kaleido allows you to convert plotly figures to images.
+
+`pip install kaleido`
 
 Right now, Kaledio v1.0.0 is available as a release candidate:
 
-* download `v1.0.0rc1` explicitly
+* download `v1.0.0rc2` explicitly **or**
 * enable whatever installer you use (`pip --pre`?) to use release candidates
 
 Kaleido's strategy has changed: `chrome` is no longer included. On the other hand,
@@ -31,82 +43,62 @@ import kaleido
 
 # fig is a plotly figure or an iterable of plotly figures
 
-async with kaleido.Kaleido(n=4, timeout=60) as k: # Those are the defaults! 4 processes, 60 seconds.
-	await k.write_fig(fig, path="./", opts={"format":"jpg"}) # default format is `png`
+# Those are the defaults! 4 processes, 90 seconds.
+async with kaleido.Kaleido(n=4, timeout=90) as k:
+  await k.write_fig(fig, path="./", opts={"format":"jpg"}) # default format is `png`
+
+# Kaleido arguments:
+# - n: how many processors to use
+# - timeout: Set a timeout on any single image write
+# - page: Customize the version of mathjax/plotly used
+
+# Kaleido.write_fig arguments:
+# - fig: a single plotly figure or an iterable
+# - path: A directory (names will be auto-generated based on title) or a single file
+# - opts: a dictionary with image options:
+#         {"scale":, "format":, "width":, "height":}
+# - error_log: If you pass a list here, image-generation errors will be appended
+#              to the list and generation continues. If left as None, the first error
+#              will cause failure.
+
+# You can also use Kaleido.write_fig_from_object:
+  await k.write_fig_from_object(fig_objects, error_log)
+
+# where fig_objects is an iterable of dictionaries that have
+# {"fig":, "path":, "opts":} keys corresponding to above.
 ```
 
-If you have to print thousands of graphs, fig can be a generator to save memory.
-It can also just be a single graph.
-
-There is a shortcut function:
+There are shortcut functions if just want dont want to create a `Kaleido()`.
 
 ```
 import asyncio
 import kaleido
-asyncio.run(kaleido.write_fig(fig, path="./", n=4))
-# this will spin the kaleido process for you with 4 processors
+asyncio.run(
+            kaleido.write_fig(
+                              fig,
+                              path="./",
+                              n=4
+                              )
+            )
 ```
 
-If you're not using async/await, wrap it all in an async function and:
-```
-asyncio.run(my_async_wrapper())
-```
+However, if you want to set timeout or custom page, you must use a `Kaleido()`.
 
-#### Older Readme Below ####
+## PageGenerators
 
-# Kaleido
-
-Kaleido is a cross-platform library for generating static images for [Plotly][plotly]'s
-visualization library. After installing it, you can use `fig.write_image("filename.png")`
-to save a plot to a file.
-
-<div align="center">
-  <a href="https://dash.plotly.com/project-maintenance">
-    <img src="https://dash.plotly.com/assets/images/maintained-by-plotly.png"
-    width="400px" alt="Maintained by Plotly">
-  </a>
-</div>
-
-## How It Works
-
-The original version of kaleido included a custom build of the Chrome web browser,
-which made it very large (hundreds of megabytes) and proved very difficult to maintain.
-In contrast, this version depends on [choreographer][choreographer],
-a lightweight library that enables remote control of browsers from Python.
-When you ask kaleido to create an image, it uses choreographer to run a headless
-instance of Chrome to render and save your figure. Please see choreographer's
-ocumentation for details.
-
-> The new version of kaleido is a work on progress;
-> we would be grateful for help testing it and improving it.
-> If you find a bug, please report it in [our GitHub repository][repo],
-> and please include a minimal reproducible example if you can.
->
-> It would also be very helpful to run the script `src/py/tests/manual.py`
-> and attach its zipped output to your bug report.
-> This will give us detailed information about the precise versions of software you
-> are using and the platform you are running on,
-> which will help us track down problems more quickly.
-
-## Installation
-
-You can install kaleido from [PyPI][pypi] using pip:
+`Kaleido(page=???)` takes a `kaleido.PageGenerator()` to customize versions.
 
 ```
-pip install kaleido
+my_page = kaleido.PageGenerator(
+                      plotly="A fully qualified link to plotly (https:// or file://)",
+                      mathjax=False # no mathjax, or another fully quality link
+                      others=["a list of other script links to include"]
+                      )
+async with kaleido.Kaleido(n=4, page=my_page) as k:
+  ...
 ```
 
-## Use
-
-Versions 4.9 and above of the Plotly Python library will automatically use kaleido
-for static image export when kaleido is installed.
-For example:
-
-```python
-import plotly.express as px
-fig = px.scatter(px.data.iris(), x="sepal_length", y="sepal_width", color="species")
-fig.write_image("figure.png", engine="kaleido")
-```
+## More info
 
 See the [Plotly static image export documentation][plotly-export] for more information.
 

--- a/src/py/kaleido/_mocker.py
+++ b/src/py/kaleido/_mocker.py
@@ -106,7 +106,7 @@ parser.add_argument(
 parser.add_argument(
     "--timeout",
     type=int,
-    default=60,
+    default=90,
     help="Set timeout in seconds for any 1 mock (default 60 seconds)",
 )
 

--- a/src/py/kaleido/_mocker.py
+++ b/src/py/kaleido/_mocker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import multiprocessing
 import sys
 import time
 import warnings
@@ -15,6 +16,8 @@ import orjson
 import kaleido
 
 _logger = logistro.getLogger(__name__)
+
+cpus = multiprocessing.cpu_count()
 
 # Extract jsons of mocks
 test_dir = Path(__file__).resolve().parent.parent / "integration_tests"
@@ -80,7 +83,12 @@ parser.add_argument(
     help="Set the logging level (default INFO)",
 )
 
-parser.add_argument("--n", type=int, default=4, help="Number of tabs, default 4")
+parser.add_argument(
+    "--n",
+    type=int,
+    default=cpus,
+    help="Number of tabs, defaults to # of cpus",
+)
 
 parser.add_argument(
     "--input",

--- a/src/py/kaleido/kaleido.py
+++ b/src/py/kaleido/kaleido.py
@@ -500,7 +500,7 @@ class Kaleido(choreo.Browser):
                 page = PageGenerator()
             page.generate_index(index)
         self._timeout = kwargs.pop("timeout", 90)
-        self._logger.debug(f"Timeout: {self._timeout}")
+        _logger.debug(f"Timeout: {self._timeout}")
         self._n = kwargs.pop("n", 1)
         self._height = kwargs.pop("height", None)
         self._width = kwargs.pop("width", None)

--- a/src/py/kaleido/kaleido.py
+++ b/src/py/kaleido/kaleido.py
@@ -500,6 +500,7 @@ class Kaleido(choreo.Browser):
                 page = PageGenerator()
             page.generate_index(index)
         self._timeout = kwargs.pop("timeout", 90)
+        self._logger.debug(f"Timeout: {self._timeout}")
         self._n = kwargs.pop("n", 1)
         self._height = kwargs.pop("height", None)
         self._width = kwargs.pop("width", None)

--- a/src/py/kaleido/kaleido.py
+++ b/src/py/kaleido/kaleido.py
@@ -475,7 +475,7 @@ class Kaleido(choreo.Browser):
 
         Args:
             n: the number of separate processes (windows, not seen) to use.
-            timeout: limit on any single render.
+            timeout: limit on any single render (default 90 seconds).
             width: width of window (headless only)
             height: height of window (headless only)
             page: This can be a `kaleido.PageGenerator`, a `pathlib.Path`, or a string.
@@ -499,7 +499,7 @@ class Kaleido(choreo.Browser):
             if not page:
                 page = PageGenerator()
             page.generate_index(index)
-        self._timeout = kwargs.pop("timeout", 60)
+        self._timeout = kwargs.pop("timeout", 90)
         self._n = kwargs.pop("n", 1)
         self._height = kwargs.pop("height", None)
         self._width = kwargs.pop("width", None)


### PR DESCRIPTION
@gvwilson I edited the [README](https://github.com/plotly/Kaleido/blob/andrew/launch/README.md) to try and push things along

###  updating plotly.io

For imitating the old blocking `fig.write_image()`, something like:

```python

def write_image_sync(self, path, opts):
      def _run_kaleido_blocking(fig, path, opts):
            asyncio.run(kaleido.write_image(fig, path, opts)
      t.Thread(target=_run_kaleido_blocking, args=(self, path, opts))
      t.start()
      t.join()
```
✅ is blocking like before
✅ won't muck around with whatever they are doing with their `asyncio.Loop`- each thread gets a new loop.

For an async version:

```python
async def write_image(self, path, opts):
          return await kaleido.write_image(self, path, opts)
```
✅ is async

Otherwise they should use the kaleido package directly.