### PR TITLE
Andrew/dimensions checks + PDF Fix

### DIFF
--- a/src/py/CHANGELOG.txt
+++ b/src/py/CHANGELOG.txt
@@ -1,3 +1,5 @@
+v1.0.0rc11
+- Write mocker tool to parameterize opts in tests
 v1.0.0rc10
 - Allow user to pass Figure-like dicts
 - Fix bug by which calc fig rejected plotly figures

--- a/src/py/CHANGELOG.txt
+++ b/src/py/CHANGELOG.txt
@@ -1,5 +1,6 @@
 v1.0.0rc11
 - Write mocker tool to parameterize opts in tests
+- Crop page to pdf size
 v1.0.0rc10
 - Allow user to pass Figure-like dicts
 - Fix bug by which calc fig rejected plotly figures

--- a/src/py/kaleido/_kaleido_tab.py
+++ b/src/py/kaleido/_kaleido_tab.py
@@ -361,7 +361,7 @@ class _KaleidoTab:
                 "marginBottom": 0.1,
                 "marginLeft": 0.1,
                 "marginRight": 0.1,
-                "preferCSSPageSize": False,
+                "preferCSSPageSize": True,
                 "pageRanges": "1",
             }
             pdf_response = await self.tab.send_command(

--- a/src/py/kaleido/_mocker.py
+++ b/src/py/kaleido/_mocker.py
@@ -112,6 +112,25 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--width",
+    type=str,
+    default=None,
+    help="width in pixels (default 700)",
+)
+parser.add_argument(
+    "--height",
+    type=str,
+    default=None,
+    help="height in pixels (default 500)",
+)
+parser.add_argument(
+    "--scale",
+    type=str,
+    default=None,
+    help="Scale ratio (default 1)",
+)
+
+parser.add_argument(
     "--timeout",
     type=int,
     default=90,

--- a/src/py/kaleido/_mocker.py
+++ b/src/py/kaleido/_mocker.py
@@ -49,6 +49,11 @@ def _load_figures_from_paths(paths: list[Path]):
                 yield {
                     "fig": figure,
                     "path": str(Path(args.output) / f"{path.stem}.{args.format}"),
+                    "opts": {
+                        "scale": args.scale,
+                        "width": args.width,
+                        "height": args.height,
+                    },
                 }
         else:
             raise RuntimeError(f"Path {path} is not a file.")

--- a/src/py/kaleido/_mocker.py
+++ b/src/py/kaleido/_mocker.py
@@ -213,6 +213,7 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
+logistro.getLogger().setLevel(args.log)
 
 if not Path(args.output).is_dir():
     raise ValueError(f"Specified output must be existing directory. Is {args.output!s}")

--- a/src/py/uv.lock
+++ b/src/py/uv.lock
@@ -236,11 +236,11 @@ wheels = [
 
 [[package]]
 name = "narwhals"
-version = "1.29.0"
+version = "1.30.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/f7/caa23ebc4aed3ef2314441c44e1d842e701adc6af57587ffda9263c03b6e/narwhals-1.29.0.tar.gz", hash = "sha256:1021c345d56c66ff0cc8e6d03ca8c543d01ffc411630973a5cb69ee86824d823", size = 248349 }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/98/be6d35e8869ab9403fa25dc3458e7af6ce36dac2873c74c7274a59b21958/narwhals-1.30.0.tar.gz", hash = "sha256:0c50cc67a5404da501302882838ec17dce51703d22cd8ad89162d6f60ea0bb19", size = 253461 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/f6/1fcd6b3d0e21d9b75e71ae68fbc92bbb9b9b1f4f33dd81c61d8f53378b30/narwhals-1.29.0-py3-none-any.whl", hash = "sha256:653aa8e5eb435816e7b50c8def17e7e5e3324c2ffd8a3eec03fef85792e9cf5e", size = 305214 },
+    { url = "https://files.pythonhosted.org/packages/e4/97/bde1e4cf1e0fe0d4c70f750b57d152c0ecb04bb35de7aa7950a5756a71d6/narwhals-1.30.0-py3-none-any.whl", hash = "sha256:443aa0a1abfae89bc65a6b888a7e310a03d1818bfb2ccd61c150199a5f954c17", size = 313611 },
 ]
 
 [[package]]


### PR DESCRIPTION
Two things in this PR:

# New Mocker Functions

- in `_mocker.py` it adds arguments for printing out the mock w/ parameterized width/scale/height

### Example

```console
$ uv run kaleido_mocker --parameterize_opts --output . --random 5 --n 15
```
the parameters are hardcoded right now, but certain values can be fixed by setting `--[format, scale, width, height] VALUE`. Otherwise, tons and tons of output. The command above, 5 mocks, 810 output files.

# Fix PDF page-size

- **makes pdf page crop to figure size** closes https://github.com/plotly/Kaleido/issues/289