### PR TITLE
Add some choreo errors to kaleido.errors

### DIFF
--- a/src/py/CHANGELOG.txt
+++ b/src/py/CHANGELOG.txt
@@ -3,6 +3,7 @@ v1.0.0rc11
 - Crop page to pdf size
 - Add type checks to user input for improved error messages
 - Fix latex strings in PDF bolding
+- Add some choreographer errors to kaleido.errors
 v1.0.0rc10
 - Allow user to pass Figure-like dicts
 - Fix bug by which calc fig rejected plotly figures

--- a/src/py/kaleido/errors.py
+++ b/src/py/kaleido/errors.py
@@ -1,8 +1,17 @@
 """A list of errors available from the kaleido package."""
 
+from choreographer.errors import (
+    BrowserClosedError,
+    BrowserFailedError,
+    ChromeNotFoundError,
+)
+
 from ._kaleido_tab import JavascriptError, KaleidoError
 
 __all__ = [
+    "BrowserClosedError",
+    "BrowserFailedError",
+    "ChromeNotFoundError",
     "JavascriptError",
     "KaleidoError",
 ]


### PR DESCRIPTION
```python
>>> from kaleido.errors import *
>>> dir()
['BrowserClosedError', 'BrowserFailedError', 'ChromeNotFoundError', 'JavascriptError', 'KaleidoError', '__annotations__', '__builtins__', '__doc__', '__loader__', '__name__', '__package__', '__spec__']
>>>
```