### PR TITLE
Handle `mathjax` arg when passed to Kaleido constructor

### DIFF
--- a/src/py/kaleido/kaleido.py
+++ b/src/py/kaleido/kaleido.py
@@ -106,6 +106,7 @@ class Kaleido(choreo.Browser):
         self._height = kwargs.pop("height", None)
         self._width = kwargs.pop("width", None)
         self._stepper = kwargs.pop("stepper", False)
+        self._mathjax = kwargs.pop("mathjax", None)
         if not kwargs.get("headless", True) and (self._height or self._width):
             warnings.warn(
                 "Height and Width can only be used if headless=True, "
@@ -135,7 +136,7 @@ class Kaleido(choreo.Browser):
             index = self.tmp_dir.path / "index.html"
             self._index = index.as_uri()
             if not page:
-                page = PageGenerator()
+                page = PageGenerator(mathjax=self._mathjax)
             page.generate_index(index)
 
     async def _conform_tabs(self, tabs=None) -> None:

--- a/src/py/tests/test_calc_fig.py
+++ b/src/py/tests/test_calc_fig.py
@@ -23,7 +23,10 @@ async def test_calc_fig():
     assert isinstance(img_awaited, bytes)
 
     # Make sure passing `mathjax` argument via `kopts` works properly
-    img_sync = kaleido.calc_fig_sync(fig, kopts=dict(mathjax="https://cdn.jsdelivr.net/npm/mathjax@3.2.1/es5/tex-svg.js"))
+    img_sync = kaleido.calc_fig_sync(
+        fig,
+        kopts={"mathjax": "https://cdn.jsdelivr.net/npm/mathjax@3.2.1/es5/tex-svg.js"},
+    )
     assert isinstance(img_sync, bytes)
 
     img_from_dict = kaleido.calc_fig_sync(fig.to_dict())

--- a/src/py/tests/test_calc_fig.py
+++ b/src/py/tests/test_calc_fig.py
@@ -22,7 +22,8 @@ async def test_calc_fig():
     img_awaited = await kaleido.calc_fig(fig)
     assert isinstance(img_awaited, bytes)
 
-    img_sync = kaleido.calc_fig_sync(fig)
+    # Make sure passing `mathjax` argument via `kopts` works properly
+    img_sync = kaleido.calc_fig_sync(fig, kopts=dict(mathjax="https://cdn.jsdelivr.net/npm/mathjax@3.2.1/es5/tex-svg.js"))
     assert isinstance(img_sync, bytes)
 
     img_from_dict = kaleido.calc_fig_sync(fig.to_dict())


### PR DESCRIPTION
Handle `mathjax` arg when passed to Kaleido constructor via `**kwargs`.

`mathjax` need to be popped from `kwargs` before `kwargs` is passed to `choreo.Browser()`; and then `mathjax` needs to be passed as an argument to `PageGenerator()`.

Without this change, calling `kaleido.calc_fig_sync(..., kopts=dict(mathjax="<mathjax-url>"))` fails with the following error raised by `choreographer`:

`RuntimeError: Chromium.get_cli() received invalid args: dict_keys(['mathjax'])`

This PR also updates the test in `test_calc_fig.py` to test passing a Mathjax url. 