### PR TITLE
Show warning if incompatible Plotly version is installed

### DIFF
--- a/src/py/CHANGELOG.txt
+++ b/src/py/CHANGELOG.txt
@@ -1,3 +1,6 @@
+Unreleased
+- Add warning if using incompatible Plotly version
+
 v1.0.0rc15
 - BUG: Add regex sanitization for auto-filename generation
 - Further santiize title to filename conversion

--- a/src/py/kaleido/_utils.py
+++ b/src/py/kaleido/_utils.py
@@ -48,7 +48,7 @@ def warn_incompatible_plotly():
         # If another error occurs, log it but do not raise
         # Since this compatibility check is just a convenience,
         # we don't want to block the whole library if there's an issue
-        _logger.info(f"Error while checking Plotly version: {e}")
+        _logger.info("Error while checking Plotly version.", exc_info=e)
 
 
 class ErrorEntry:

--- a/src/py/kaleido/_utils.py
+++ b/src/py/kaleido/_utils.py
@@ -1,12 +1,48 @@
 import asyncio
+from importlib.metadata import version, PackageNotFoundError
 import traceback
 from functools import partial
+import warnings
+
+import logistro
+from packaging.version import Version
+
+_logger = logistro.getLogger(__name__)
 
 
 async def to_thread(func, *args, **kwargs):
     _loop = asyncio.get_running_loop()
     fn = partial(func, *args, **kwargs)
     await _loop.run_in_executor(None, fn)
+
+
+def warn_incompatible_plotly():
+    """
+    Check if the installed Plotly version (if any) is compatible with this version of Kaleido.
+    If not, display a warning.
+    """
+    try:
+        min_compatible_plotly_version = Version("6.1.1")
+        installed_plotly_version = Version(version("plotly"))
+        installed_kaleido_version = Version(version("kaleido"))
+        if installed_plotly_version < min_compatible_plotly_version:
+            warnings.warn(
+                "\n\n"
+                f"Warning: You have Plotly version {installed_plotly_version}, "
+                f"which is not compatible with this version of Kaleido ({installed_kaleido_version}).\n\n"
+                "This means that image generation (e.g. `fig.write_image()`) will not work.\n\n"
+                f"Please upgrade Plotly to at least {min_compatible_plotly_version}, or downgrade Kaleido."
+                "\n\n",
+                UserWarning,
+            )
+    except PackageNotFoundError:
+        # If Plotly is not installed, there's nothing to worry about
+        pass
+    except Exception as e:
+        # If another error occurs, log it but do not raise
+        # Since this compatibility check is just a convenience,
+        # we don't want to block the whole library if there's an issue
+        _logger.info(f"Error while checking Plotly version: {e}")
 
 
 class ErrorEntry:

--- a/src/py/kaleido/_utils.py
+++ b/src/py/kaleido/_utils.py
@@ -1,8 +1,8 @@
 import asyncio
-from importlib.metadata import version, PackageNotFoundError
 import traceback
-from functools import partial
 import warnings
+from functools import partial
+from importlib.metadata import PackageNotFoundError, version
 
 import logistro
 from packaging.version import Version
@@ -18,7 +18,8 @@ async def to_thread(func, *args, **kwargs):
 
 def warn_incompatible_plotly():
     """
-    Check if the installed Plotly version (if any) is compatible with this version of Kaleido.
+    Check if installed Plotly version (if any) is compatible with this Kaleido version.
+
     If not, display a warning.
     """
     try:
@@ -29,15 +30,20 @@ def warn_incompatible_plotly():
             warnings.warn(
                 "\n\n"
                 f"Warning: You have Plotly version {installed_plotly_version}, "
-                f"which is not compatible with this version of Kaleido ({installed_kaleido_version}).\n\n"
-                "This means that image generation (e.g. `fig.write_image()`) will not work.\n\n"
-                f"Please upgrade Plotly to at least {min_compatible_plotly_version}, or downgrade Kaleido."
+                "which is not compatible with this version of "
+                f"Kaleido ({installed_kaleido_version}).\n\n"
+                "This means that image generation (e.g. `fig.write_image()`) "
+                "will not work.\n\n"
+                f"Please upgrade Plotly to at least {min_compatible_plotly_version}, "
+                "or downgrade Kaleido."
                 "\n\n",
                 UserWarning,
+                stacklevel=2,
             )
     except PackageNotFoundError:
         # If Plotly is not installed, there's nothing to worry about
         pass
+    # ruff: noqa: BLE001
     except Exception as e:
         # If another error occurs, log it but do not raise
         # Since this compatibility check is just a convenience,

--- a/src/py/kaleido/_utils.py
+++ b/src/py/kaleido/_utils.py
@@ -32,13 +32,13 @@ def warn_incompatible_plotly():
                 f"Warning: You have Plotly version {installed_plotly_version}, "
                 "which is not compatible with this version of "
                 f"Kaleido ({installed_kaleido_version}).\n\n"
-                "This means that image generation (e.g. `fig.write_image()`) "
+                "This means that static image generation (e.g. `fig.write_image()`) "
                 "will not work.\n\n"
-                f"Please upgrade Plotly to at least {min_compatible_plotly_version}, "
-                "or downgrade Kaleido."
-                "\n\n",
+                f"Please upgrade Plotly to version {min_compatible_plotly_version} "
+                "or greater, or downgrade Kaleido to version 0.2.1."
+                "\n",
                 UserWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
     except PackageNotFoundError:
         # If Plotly is not installed, there's nothing to worry about

--- a/src/py/kaleido/kaleido.py
+++ b/src/py/kaleido/kaleido.py
@@ -16,9 +16,12 @@ from choreographer.utils import TmpDirectory
 from ._fig_tools import _is_figurish, build_fig_spec
 from ._kaleido_tab import _KaleidoTab
 from ._page_generator import PageGenerator
-from ._utils import ErrorEntry
+from ._utils import ErrorEntry, warn_incompatible_plotly
 
 _logger = logistro.getLogger(__name__)
+
+# Show a warning if the installed Plotly version is incompatible with this version of Kaleido
+warn_incompatible_plotly()
 
 
 def _make_printer(name):

--- a/src/py/kaleido/kaleido.py
+++ b/src/py/kaleido/kaleido.py
@@ -20,7 +20,8 @@ from ._utils import ErrorEntry, warn_incompatible_plotly
 
 _logger = logistro.getLogger(__name__)
 
-# Show a warning if the installed Plotly version is incompatible with this version of Kaleido
+# Show a warning if the installed Plotly version
+# is incompatible with this version of Kaleido
 warn_incompatible_plotly()
 
 

--- a/src/py/pyproject.toml
+++ b/src/py/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "choreographer>=1.0.5",
   "logistro>=1.0.8",
   "orjson>=3.10.15",
+  "packaging",
 ]
 
 [project.urls]


### PR DESCRIPTION
Adds a warning on `import kaleido` if the environment has `plotly` installed AND the `plotly` version is less than 6.1.1.

Looks like this:
![Screen Shot 2025-06-13 at 11 05 32 AM](https://github.com/user-attachments/assets/753d1743-7393-47d1-af6a-e17436ad39e0)

## Steps for testing

1. Install this branch: `pip install 'git+https://github.com/plotly/Kaleido.git@warn-plotly-version#subdirectory=src/py'
2. Install incompatible Plotly: `pip install plotly==6.0.1`
3. Execute `import kaleido` in the Python shell or inside a Python script and verify that the warning above is shown
4. Install compatible Plotly: `pip install plotly==6.1.2`
5. Execute `import kaleido` again and verify that no warning is shown 
