### PR TITLE
fix: move pytest-timeout to dev-dependency

### DIFF
--- a/src/py/pyproject.toml
+++ b/src/py/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
   "logistro>=1.0.8",
   "orjson>=3.10.15",
   "packaging",
-  "pytest-timeout>=2.4.0",
 ]
 
 [project.urls]
@@ -45,6 +44,7 @@ kaleido_get_chrome = "choreographer.cli._cli_utils:get_chrome_cli"
 dev = [
   "pytest",
   "pytest-asyncio",
+  "pytest-timeout>=2.4.0",
   "pytest-xdist",
   "async-timeout",
   "mypy>=1.14.1",

--- a/src/py/uv.lock
+++ b/src/py/uv.lock
@@ -481,7 +481,6 @@ dependencies = [
     { name = "orjson", version = "3.10.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "orjson", version = "3.11.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "packaging" },
-    { name = "pytest-timeout" },
 ]
 
 [package.dev-dependencies]
@@ -501,6 +500,7 @@ dev = [
     { name = "pytest-asyncio", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest-asyncio", version = "1.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest-order" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -523,7 +523,6 @@ requires-dist = [
     { name = "logistro", specifier = ">=1.0.8" },
     { name = "orjson", specifier = ">=3.10.15" },
     { name = "packaging" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -537,6 +536,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-order", specifier = ">=1.3.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
 ]


### PR DESCRIPTION
https://github.com/plotly/Kaleido/pull/397 started to use `pytest-timeout` but it seems that the package uses only for testging. As reported in https://github.com/plotly/Kaleido/issues/414, now kaleido is shipped with pytest related packages. I think these are not intended and users would not need them at runtime.