### PR TITLE
Fix packaging to install only the `kaleido` module

### DIFF
--- a/src/py/pyproject.toml
+++ b/src/py/pyproject.toml
@@ -2,8 +2,8 @@
 requires = ["setuptools>=65.0.0", "wheel", "setuptools-git-versioning"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools.packages]
-find = {namespaces = true}
+[tool.setuptools]
+packages = ["kaleido"]
 
 [tool.setuptools-git-versioning]
 enabled = true


### PR DESCRIPTION
As explained in #414, the current configuration causes `tests` and `doc` folders to be installed alongside the package.
This PR updates `pyproject.toml` to explicitly install only the `kaleido` package, preventing unintended directories (`tests`, `doc`) from being included in the distribution.