### PR TITLE
Fix deadlock in GlobalKaleidoServer.call_function() under concurrent …

### DIFF
--- a/src/py/kaleido/_sync_server.py
+++ b/src/py/kaleido/_sync_server.py
@@ -18,6 +18,7 @@ class Task(NamedTuple):
     fn: str
     args: Any
     kwargs: Any
+    result_queue: Queue  # per-caller mailbox
 
 
 class _BadFunctionName(BaseException):
@@ -37,13 +38,11 @@ class GlobalKaleidoServer:
                 if not hasattr(k, task.fn):
                     raise _BadFunctionName(f"Kaleido has no attribute {task.fn}")
                 try:
-                    self._return_queue.put(
+                    task.result_queue.put(
                         await getattr(k, task.fn)(*task.args, **task.kwargs),
                     )
                 except Exception as e:  # noqa: BLE001
-                    self._return_queue.put(e)
-
-                self._task_queue.task_done()
+                    task.result_queue.put(e)
 
     def __new__(cls):
         # Create the singleton on first instantiation
@@ -72,7 +71,6 @@ class GlobalKaleidoServer:
             daemon=True,
         )
         self._task_queue: Queue[Task | None] = Queue()
-        self._return_queue: Queue[Any] = Queue()
         self._thread.start()
         self._initialized = True
         close = partial(self.close, silence_warnings=True)
@@ -92,7 +90,6 @@ class GlobalKaleidoServer:
         self._thread.join()
         del self._thread
         del self._task_queue
-        del self._return_queue
         self._initialized = False
 
     def call_function(self, cmd: str, *args: Any, **kwargs: Any):
@@ -117,9 +114,9 @@ class GlobalKaleidoServer:
                 UserWarning,
                 stacklevel=3,
             )
-        self._task_queue.put(Task(cmd, args, kwargs))
-        self._task_queue.join()
-        res = self._return_queue.get()
+        my_queue: Queue[Any] = Queue(maxsize=1)
+        self._task_queue.put(Task(cmd, args, kwargs, my_queue))
+        res = my_queue.get()
         if isinstance(res, BaseException):
             raise res
         else:


### PR DESCRIPTION
…access

The shared _return_queue causes a race condition when multiple threads call to_image concurrently: task_queue.join() unblocks all waiters when the count hits zero, not when a specific task completes. Two threads race to return_queue.get(), one wins, the other blocks forever.

Fix: give each caller its own Queue embedded in the Task. The server routes the result directly into it. No sharing, no race, no deadlock.

Reproduces ~1/1000 calls with 64 threads.
See https://github.com/plotly/Kaleido/issues/441