### PR TITLE
fix: Make orjson an optional dependency

### DIFF
--- a/src/py/kaleido/_kaleido_tab/_tab.py
+++ b/src/py/kaleido/_kaleido_tab/_tab.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import base64
-from typing import TYPE_CHECKING
+import json as _stdlib_json
+from typing import TYPE_CHECKING, Any
 
 import logistro
-import orjson
+
+try:
+    import orjson
+except ImportError:  # pragma: no cover - exercised only when orjson is absent
+    orjson = None  # type: ignore[assignment]
 
 from . import _devtools_utils as _dtools
 from . import _js_logger
@@ -30,6 +35,37 @@ def _orjson_default(obj):
     if hasattr(obj, "tolist"):
         return obj.tolist()
     raise TypeError(f"Type is not JSON serializable: {type(obj).__name__}")
+
+
+class _StdlibJSONEncoder(_stdlib_json.JSONEncoder):
+    """
+    Encoder used when ``orjson`` is unavailable; mirrors ``_orjson_default``.
+
+    Reproduces the ``orjson.OPT_SERIALIZE_NUMPY`` behavior via the standard
+    ``.tolist()`` round-trip so callers see the same output regardless of
+    whether ``orjson`` is installed.
+    """
+
+    def default(self, o: Any) -> Any:
+        if hasattr(o, "tolist"):
+            return o.tolist()
+        return super().default(o)
+
+
+def _serialize_spec(spec: Any) -> str:
+    """
+    Serialize a figure spec to a JSON string.
+
+    Uses :mod:`orjson` when available (fast path with native NumPy support);
+    falls back to the standard-library :mod:`json` module otherwise.
+    """
+    if orjson is not None:
+        return orjson.dumps(
+            spec,
+            default=_orjson_default,
+            option=orjson.OPT_SERIALIZE_NUMPY,
+        ).decode()
+    return _stdlib_json.dumps(spec, cls=_StdlibJSONEncoder)
 
 
 def _subscribe_new(tab: choreo.Tab, event: str) -> asyncio.Future:
@@ -148,11 +184,7 @@ class _KaleidoTab:
         stepper,
     ) -> bytes:
         render_prof.profile_log.tick("serializing spec")
-        spec_str = orjson.dumps(
-            spec,
-            default=_orjson_default,
-            option=orjson.OPT_SERIALIZE_NUMPY,
-        ).decode()
+        spec_str = _serialize_spec(spec)
         render_prof.profile_log.tick("spec serialized")
 
         render_prof.profile_log.tick("sending javascript")

--- a/src/py/kaleido/mocker/_utils.py
+++ b/src/py/kaleido/mocker/_utils.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 import itertools
+import json as _stdlib_json
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
 import logistro
-import orjson
+
+try:
+    import orjson
+except ImportError:  # pragma: no cover - exercised only when orjson is absent
+    orjson = None  # type: ignore[assignment]
 
 from ._args import args
 
@@ -44,30 +49,34 @@ def load_figures_from_paths(paths: list[Path]) -> Generator[FigureDict, None]:
         if not path.is_file():
             raise RuntimeError(f"Path {path} is not a file.")
         _logger.info(f"Found file: {path!s}")
-        with path.open(encoding="utf-8") as file:
-            figure = orjson.loads(file.read())
-            for f, w, h, s in itertools.product(  # all combos
-                args.format,
-                args.width,
-                args.height,
-                args.scale,
-            ):
-                name = (
-                    f"{path.stem}.{f!s}"
-                    if not args.parameterize
-                    else f"{path.stem!s}-{w!s}x{h!s}@{s!s}.{f!s}"
-                )
-                opts: LayoutOpts = {
-                    "scale": s,
-                    "width": w,
-                    "height": h,
-                }
-                _logger.info(f"Yielding spec: {name!s}")
-                yield {
-                    "fig": figure,
-                    "path": str(Path(args.output) / name),
-                    "opts": opts,
-                }
+        if orjson is not None:
+            with path.open("rb") as file:
+                figure = orjson.loads(file.read())
+        else:
+            with path.open(encoding="utf-8") as file:
+                figure = _stdlib_json.load(file)
+        for f, w, h, s in itertools.product(  # all combos
+            args.format,
+            args.width,
+            args.height,
+            args.scale,
+        ):
+            name = (
+                f"{path.stem}.{f!s}"
+                if not args.parameterize
+                else f"{path.stem!s}-{w!s}x{h!s}@{s!s}.{f!s}"
+            )
+            opts: LayoutOpts = {
+                "scale": s,
+                "width": w,
+                "height": h,
+            }
+            _logger.info(f"Yielding spec: {name!s}")
+            yield {
+                "fig": figure,
+                "path": str(Path(args.output) / name),
+                "opts": opts,
+            }
 
     class FigureDict(TypedDict):
         """The type a fig_dicts returns for `write_fig_from_object`."""

--- a/src/py/pyproject.toml
+++ b/src/py/pyproject.toml
@@ -28,9 +28,11 @@ maintainers = [
 dependencies = [
   "choreographer>=1.3.0",
   "logistro>=1.0.8",
-  "orjson>=3.10.15",
   "packaging",
 ]
+
+[project.optional-dependencies]
+orjson = ["orjson>=3.10.15"]
 
 [project.urls]
 Homepage = "https://github.com/plotly/kaleido"


### PR DESCRIPTION
Closes #423.

Makes `orjson` an optional dependency with a stdlib `json` fallback, so users who can't (or don't want to) install `orjson` — e.g. on Python 3.14t, in minimal/locked-down environments, or just to reduce the dependency footprint — can install Kaleido without it.

### What changes for users

```bash
pip install kaleido            # stdlib JSON path (smaller install, no orjson)
pip install kaleido[orjson]    # fast path with orjson (unchanged behavior)
```

The default install no longer pulls `orjson`. Anyone who wants the speed benefit opts in via the new `orjson` extra.

### Files touched

- `src/py/pyproject.toml` — `orjson>=3.10.15` moved from `dependencies` to `[project.optional-dependencies]` as `orjson = ["orjson>=3.10.15"]`.
- `src/py/kaleido/_kaleido_tab/_tab.py` — adds `_StdlibJSONEncoder` (a `json.JSONEncoder` subclass that mirrors `_orjson_default` by calling `.tolist()` on NumPy-like objects) and `_serialize_spec(spec)` (picks orjson when present, stdlib otherwise). The single call site in `_calc_fig` becomes `spec_str = _serialize_spec(spec)`.
- `src/py/kaleido/mocker/_utils.py` — same import-guard pattern; load path now reads as bytes when orjson is available, as utf-8 text when it isn't. The yield loop is moved out of the `with path.open(...)` block so it runs the same way under both branches (file is closed sooner; behavior visible to consumers is unchanged).

### How I verified

- `pip install -e .` → orjson absent → `kaleido._kaleido_tab._tab.orjson is None` → stdlib path taken
- `pip install -e ".[orjson]"` → orjson present → fast path taken
- Round-trip test on a representative spec (`np.arange`, `np.linspace`, `np.array(["a", ...])`, `np.int32(8)` nested) showed both paths produce **semantically equivalent JSON** after `json.loads`: identical Python objects. Outputs differ only in whitespace (orjson is compact; stdlib uses default separators) — both are valid input for the JS-side `JSON.parse`.
- `ruff check` — clean on all three files
- `ruff format --check` — clean
- The pure-Python tests (`tests/test_utils.py`, `tests/test_path_tools.py`, `tests/test_placeholder.py`) pass. The browser-dependent tests in `tests/test_encoder_one_off.py` etc. couldn't be run locally without Chrome; full CI will exercise them.

### Notes for review

- One subtle behavior change in `mocker/_utils.py`: the `for f, w, h, s in itertools.product(...)` yield loop was originally nested inside `with path.open(...)`, so the JSON file stayed open during iteration. The new structure closes the file immediately after parsing and then iterates. The yielded data is identical; this is purely a resource-management improvement.
- The stdlib `JSONEncoder` cannot match `orjson`'s exact byte-level output (no `OPT_SERIALIZE_NUMPY`, different whitespace). The downstream consumer is `JSON.parse(specStr)` on the JS side, which is whitespace-tolerant — semantic equivalence is what matters and is verified.

### AI disclosure

This change was authored with Claude Code assistance. I read the full diff, ran the verification steps above myself, and can explain every change.
