### PR TITLE
Serialize datetime-like values in _orjson_default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Fixed
-- Fixed `TypeError: Type is not JSON serializable: Timestamp` when a figure contains datetime-like values such as a `pandas` `Timestamp`; these now serialize to ISO strings [[#458](https://github.com/plotly/Kaleido/issues/458)]
+- Fixed `TypeError: Type is not JSON serializable: Timestamp` when a figure contains datetime-like values such as a `pandas` `Timestamp`; these now serialize to ISO strings [[#458](https://github.com/plotly/Kaleido/issues/458)], with thanks to @gaoflow for the contribution!
 
 ## v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Fixed
+- Fixed `TypeError: Type is not JSON serializable: Timestamp` when a figure contains datetime-like values such as a `pandas` `Timestamp`; these now serialize to ISO strings [[#458](https://github.com/plotly/Kaleido/issues/458)]
+
 ## v1.3.0
 
 ### Added

--- a/src/py/kaleido/_kaleido_tab/_tab.py
+++ b/src/py/kaleido/_kaleido_tab/_tab.py
@@ -30,6 +30,8 @@ def _orjson_default(obj):
     """Fallback for types orjson can't handle natively (e.g. NumPy string arrays)."""
     if isinstance(obj, Decimal):
         return float(obj)
+    if hasattr(obj, "isoformat"):  # datetime-like, e.g. pandas Timestamp (#458)
+        return obj.isoformat()
     if hasattr(obj, "tolist"):
         return obj.tolist()
     raise TypeError(f"Type is not JSON serializable: {type(obj).__name__}")

--- a/src/py/tests/test_orjson_encoder.py
+++ b/src/py/tests/test_orjson_encoder.py
@@ -17,6 +17,12 @@ def test_orjson_default_handles_datetime_like():
     a_date = datetime.date(2026, 1, 2)
     assert _orjson_default(a_date) == a_date.isoformat()
 
+    # tz-aware Timestamps keep their offset (unlike plotly.py's cleaner, which
+    # drops tz on scalars via .to_pydatetime()). Plotly.js parses either form.
+    tz_ts = pd.Timestamp("2026-06-03 12:00:00", tz="UTC")
+    assert _orjson_default(tz_ts) == tz_ts.isoformat()
+    assert _orjson_default(tz_ts).endswith("+00:00")
+
     # A figure spec carrying a Timestamp now round-trips through orjson.
     spec = {"x": [ts]}
     dumped = orjson.dumps(

--- a/src/py/tests/test_orjson_encoder.py
+++ b/src/py/tests/test_orjson_encoder.py
@@ -1,0 +1,31 @@
+import datetime
+from decimal import Decimal
+
+import numpy as np
+import orjson
+import pandas as pd
+
+from kaleido._kaleido_tab._tab import _orjson_default
+
+
+def test_orjson_default_handles_datetime_like():
+    # A pandas Timestamp has no ``.tolist()`` and used to raise TypeError (#458);
+    # _orjson_default should fall back to an ISO string, like Plotly's encoder.
+    ts = pd.Timestamp("2026-06-03 12:00:00")
+    assert _orjson_default(ts) == ts.isoformat()
+
+    a_date = datetime.date(2026, 1, 2)
+    assert _orjson_default(a_date) == a_date.isoformat()
+
+    # A figure spec carrying a Timestamp now round-trips through orjson.
+    spec = {"x": [ts]}
+    dumped = orjson.dumps(
+        spec, default=_orjson_default, option=orjson.OPT_SERIALIZE_NUMPY
+    )
+    assert ts.isoformat().encode() in dumped
+
+    # Existing fallbacks are unaffected.
+    decimal_value = Decimal("1.5")
+    assert _orjson_default(decimal_value) == float(decimal_value)
+    array_values = [1, 2, 3]
+    assert _orjson_default(np.array(array_values)) == array_values


### PR DESCRIPTION
## Summary

Exporting a figure that contains a datetime-like value — e.g. a `pandas` `Timestamp` used as a marker position — raises:

```
TypeError: Type is not JSON serializable: Timestamp
```

(reported in #458, a regression in 1.3.0). The orjson fallback `_orjson_default` only handles `Decimal` and objects exposing `.tolist()` (NumPy). A `Timestamp` has neither, so it falls through to `raise TypeError`.

## Fix

Serialize datetime-like objects — anything with `.isoformat()` (`pandas` `Timestamp`, `datetime`, `date`) — to ISO strings, which is how Plotly's own JSON encoder represents them. The check is placed before the `.tolist()` branch so `numpy.datetime64` (which has `.tolist()` but no `.isoformat()`) is unaffected.

Closes #458.

## Tests

Added a unit test for `_orjson_default` covering a `Timestamp`, a `date`, an end-to-end `orjson.dumps` of a spec carrying a `Timestamp`, and the existing `Decimal`/NumPy fallbacks. It fails on `master` with the original `TypeError` and passes with the fix.
