### PR TITLE
Change default MathJax URL to v3 rather than v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### Fixed
+- Fix datetime-like values JSON serialization regression [[#461](https://github.com/plotly/Kaleido/pull/461)]
+
+### Changed
+- Switch default MathJax version from v2 to v3 [[#469](https://github.com/plotly/Kaleido/pull/469)]
+
 ## v1.3.0
 
 ### Added

--- a/src/js/src/plotly/constants.js
+++ b/src/js/src/plotly/constants.js
@@ -32,8 +32,6 @@ module.exports = {
     svg: /^data:image\/svg\+xml,/
   },
 
-  mathJaxConfigQuery: '?config=TeX-AMS-MML_SVG',
-
   // time [in ms] after which printToPDF errors when image isn't loaded
   pdfPageLoadImgTimeout: 20000
 }

--- a/src/py/kaleido/_page_generator.py
+++ b/src/py/kaleido/_page_generator.py
@@ -17,11 +17,8 @@ if TYPE_CHECKING:
 
 _logger = logistro.getLogger(__name__)
 
-DEFAULT_PLOTLY = "https://cdn.plot.ly/plotly-2.35.2.js"
-DEFAULT_MATHJAX = (
-    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js"
-    "?config=TeX-AMS-MML_SVG"
-)
+DEFAULT_PLOTLY = "https://cdn.plot.ly/plotly-3.7.0.js"
+DEFAULT_MATHJAX = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-svg.min.js"
 
 KJS_PATH = Path(__file__).resolve().parent / "vendor" / "kaleido_scopes.js"
 
@@ -54,12 +51,6 @@ class PageGenerator:
     <head>
         <style id="head-style"></style>
         <title>Kaleido-fier</title>
-        <script>
-          window.PlotlyConfig = {MathJaxConfig: 'local'}
-        </script>
-        <script type="text/x-mathjax-config">
-          MathJax.Hub.Config({ "SVG": { blacker: 0 }})
-        </script>
 """
     """The header is the HTML that always goes at the top. Rarely needs changing."""
 

--- a/src/py/kaleido/kaleido.py
+++ b/src/py/kaleido/kaleido.py
@@ -143,7 +143,7 @@ class Kaleido(choreo.Browser):
 
             mathjax (str | Path | Literal[False] | None, optional):
                 A path or URL to a mathjax.js file. If False, mathjax is
-                disabled. Defaults to None- which means to use version 2.35 via
+                disabled. If not provided, Kaleido will use MathJax v3 via
                 CDN.
 
             headers (dict[str, str] | None, optional):

--- a/src/py/kaleido/vendor/kaleido_scopes.js
+++ b/src/py/kaleido/vendor/kaleido_scopes.js
@@ -2638,8 +2638,6 @@ module.exports = {
     svg: /^data:image\/svg\+xml,/
   },
 
-  mathJaxConfigQuery: '?config=TeX-AMS-MML_SVG',
-
   // time [in ms] after which printToPDF errors when image isn't loaded
   pdfPageLoadImgTimeout: 20000
 }

--- a/src/py/tests/test_page_generator.py
+++ b/src/py/tests/test_page_generator.py
@@ -25,12 +25,6 @@ EXPECTED_BOILERPLATE = """<!DOCTYPE html>
     <head>
         <style id="head-style"></style>
         <title>Kaleido-fier</title>
-        <script>
-          window.PlotlyConfig = {MathJaxConfig: 'local'}
-        </script>
-        <script type="text/x-mathjax-config">
-          MathJax.Hub.Config({ "SVG": { blacker: 0 }})
-        </script>
 
     </head>
     <body style="{margin: 0; padding: 0;}"><img id="kaleido-image" /></body>


### PR DESCRIPTION
Closes #462 

The next major Plotly.js release will [drop MathJax v2 support](https://github.com/plotly/plotly.js/pull/7898), so before releasing that version in Plotly.py we will need to update Kaleido to use MathJax v3 (or v4) rather than v2 by default, so that everything works smoothly together.

I've made the change to v3 in this PR, but v4 would also be reasonable IMO.